### PR TITLE
Write a textual display function for the loglevels in the place of the uses of show.

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -65,7 +65,7 @@ writeProject (ProjectSettings opts pkgDesc libTarget exeTarget testTarget)
       message opts T.Error "no package name given, so no .cabal file can be generated\n"
   | otherwise = do
       -- clear prompt history a bit"
-      message opts T.Log $
+      message opts T.Info $
         "Using cabal specification: "
           ++ showCabalSpecVersion (_optCabalSpec opts)
 
@@ -269,7 +269,7 @@ writeFileSafe opts fileName content = do
 
   go exists
 
-  message opts T.Log $ show action ++ " file " ++ fileName ++ "..."
+  message opts T.Info $ show action ++ " file " ++ fileName ++ "..."
   return $ action == Existing
   where
     doOverwrite = _optOverwrite opts
@@ -279,7 +279,7 @@ writeFileSafe opts fileName content = do
           writeFile fileName content
       | exists && doOverwrite = do
           newName <- findNewPath fileName
-          message opts T.Log $
+          message opts T.Info $
             concat
               [ fileName
               , " already exists. Backing up old version in "
@@ -302,7 +302,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
 
   go dir exists
 
-  message opts T.Log $ show action ++ " directory ./" ++ dir ++ "..."
+  message opts T.Info $ show action ++ " directory ./" ++ dir ++ "..."
   return $ action == Existing
   where
     doOverwrite = _optOverwrite opts
@@ -312,7 +312,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
           createDirectory dir
       | exists && doOverwrite = do
           newDir <- findNewPath dir
-          message opts T.Log $
+          message opts T.Info
             concat
               [ dir
               , " already exists. Backing up old version in "

--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -312,7 +312,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
           createDirectory dir
       | exists && doOverwrite = do
           newDir <- findNewPath dir
-          message opts T.Log $
+          message opts T.Info $
             concat
               [ dir
               , " already exists. Backing up old version in "

--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -312,7 +312,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
           createDirectory dir
       | exists && doOverwrite = do
           newDir <- findNewPath dir
-          message opts T.Info
+          message opts T.Log $
             concat
               [ dir
               , " already exists. Backing up old version in "

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -455,7 +455,7 @@ newtype BreakException = BreakException String deriving (Eq, Show)
 instance Exception BreakException
 
 -- | Used to inform the intent of prompted messages.
-data Severity = Log | Info | Warning | Error deriving (Eq, Show)
+data Severity = Info | Warning | Error deriving (Eq, Show)
 
 -- | Convenience alias for the literate haskell flag
 type IsLiterate = Bool

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -214,7 +214,7 @@ retrieveDependencies v flags mods' pkgIx = do
       modDeps = map (\(mn, ds) -> (mn, ds, M.lookup ds modMap)) mods
   -- modDeps = map (id &&& flip M.lookup modMap) mods
 
-  message v Log "Guessing dependencies..."
+  message v Info "Guessing dependencies..."
   nub . catMaybes <$> traverse (chooseDep v flags) modDeps
 
 -- Given a module and a list of installed packages providing it,

--- a/cabal-install/tests/IntegrationTests2/config/default-config
+++ b/cabal-install/tests/IntegrationTests2/config/default-config
@@ -25,8 +25,8 @@ repository hackage.haskell.org
 -- store-dir:
 -- active-repositories:
 -- local-no-index-repo:
-remote-repo-cache: /home/colton/.cabal/packages
--- logs-dir: /home/colton/.cabal/logs
+remote-repo-cache: /home/alex/.cabal/packages
+-- logs-dir: /home/alex/.cabal/logs
 -- default-user-config:
 -- verbose: 1
 -- compiler: ghc
@@ -104,12 +104,13 @@ remote-repo-cache: /home/colton/.cabal/packages
 -- index-state:
 -- root-cmd:
 -- symlink-bindir:
-build-summary: /home/colton/.cabal/logs/build.log
+build-summary: /home/alex/.cabal/logs/build.log
 -- build-log:
 remote-build-reporting: none
 -- report-planning-failure: False
 -- per-component: True
 -- run-tests:
+-- semaphore: False
 jobs: $ncpus
 -- keep-going: False
 -- offline: False
@@ -117,11 +118,12 @@ jobs: $ncpus
 -- package-env:
 -- overwrite-policy:
 -- install-method:
-installdir: /home/colton/.cabal/bin
+installdir: /home/alex/.cabal/bin
 -- token:
 -- username:
 -- password:
 -- password-command:
+-- multi-repl:
 -- builddir:
 
 haddock
@@ -161,7 +163,7 @@ init
   -- source-dir: src
 
 install-dirs user
-  -- prefix: /home/colton/.cabal
+  -- prefix: /home/alex/.cabal
   -- bindir: $prefix/bin
   -- libdir: $prefix/lib
   -- libsubdir: $abi/$libname


### PR DESCRIPTION
- [x] Remove the loglevel entry for Log, replacing places where it was used with Info (presumably, to be reviewed later)
  - `grep -r "T.Log" ../Init`, check for entries outside `FileCreators.hs`
  - run `cabal test cabal-install`
- [ ] Not defer to `Show`, deleting the `Show` instance for `Severity`.
- [ ] Write a textual display function for the loglevels in the place of the uses of show.